### PR TITLE
Add DB k8s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,8 @@ cmd/haiku-auth/haiku-auth
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# k8 secrets
+*secrets.yaml
+
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/k8s/db/deploy.yaml
+++ b/k8s/db/deploy.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: haiku
+    service: db
+  name: haiku-db
+  namespace: haiku
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: haiku
+      service: db
+  template:
+    metadata:
+      labels:
+        app: haiku
+        service: db
+    spec:
+      containers:
+      - env:
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: haiku-db-creds
+        image: postgres:14.1
+        imagePullPolicy: IfNotPresent
+        name: haiku-db
+        resources:
+          limits:
+            cpu: 500m
+          requests:
+            cpu: 250m
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: haiku-db
+      volumes:
+      - name: haiku-db
+        persistentVolumeClaim:
+          claimName: haiku-db

--- a/k8s/db/persistent-volume-claim.yaml
+++ b/k8s/db/persistent-volume-claim.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: haiku
+    service: db
+  name: haiku-db
+  namespace: haiku
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: nfs
+  volumeMode: Filesystem
+  volumeName: haiku-db

--- a/k8s/db/persistent-volume.yaml
+++ b/k8s/db/persistent-volume.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  labels:
+    app: haiku
+    service: db
+  name: haiku-db
+spec:
+  accessModes:
+  - ReadWriteMany
+  capacity:
+    storage: 10Gi
+  nfs:
+    path: /mnt/primary/iocage/laniakea/haiku-db
+    server: 10.0.1.100
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: nfs
+  volumeMode: Filesystem

--- a/k8s/db/service.yaml
+++ b/k8s/db/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: haiku
+    service: db
+  name: haiku-db
+  namespace: haiku
+spec:
+  ports:
+  - port: 5432
+    protocol: TCP
+    targetPort: 5432
+  selector:
+    app: haiku
+    service: db
+  sessionAffinity: None
+  type: ClusterIP


### PR DESCRIPTION
Here we add a basic postgres database to kubernetes in the `haiku` namespace. This database is live, running, and accessible from within kubernetes. 